### PR TITLE
Set up docker for datm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+#
+# Deterministic Arrival Time Monitor Dockerfile
+#
+FROM centos7
+MAINTAINER Abdullah P Rashed Ahmed <apra@slac.stanford.edu>
+
+# Install yum packages
+RUN yum clean all && yum -y install bzip2.x86_64 libgomp.x86_64 telnet.x86_64 gcc-c++ strace curl
+
+# Install Miniconda2 and add it to the path
+RUN curl -sSL https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -o /tmp/miniconda.sh
+RUN chmod +x /tmp/miniconda.sh
+RUN bash /tmp/miniconda.sh -bfp /usr/local
+RUN rm -rf /tmp/miniconda.sh
+RUN conda update --yes conda
+RUN conda install --yes python=2
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh
+
+# Conda install psana
+RUN conda install --yes --channel lcls-rhel7 psana-conda
+RUN conda install --yes --channel conda-forge "mpich>=3" mpi4py h5py pytables libtiff=4.0.6 
+RUN rm -rf /opt/conda/lib/python2.7/site-packages/numexpr-2.6.2-py2.7.egg-info
+
+# Install datm requirements from the master branch
+RUN conda install --yes --channel conda-forge `curl https://raw.githubusercontent.com/slaclab/datm/master/requirements.txt`
+
+# Install additional packages
+RUN conda install --yes --channel conda-forge ipython ipdb 
+
+# Clean up
+RUN conda clean --all --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Deterministic Arrival Time Monitor Dockerfile
 #
-FROM centos7
+FROM centos:7
 MAINTAINER Abdullah P Rashed Ahmed <apra@slac.stanford.edu>
 
 # Install yum packages

--- a/README.rst
+++ b/README.rst
@@ -19,13 +19,37 @@ If using conda: ::
 
   $ conda install `cat requirements.txt` -c conda-forge
 
+
+Docker
+======
+
+The dockerfile included in the repo contains all the necessary components to run
+``datm``. If running this from ``daq-tst-dev05``, a slight modification needs to
+be made to the Dockerfile. Simply remove the colon in line 4 so that it reads as
+the following: ::
+
+  3| #
+  4| FROM centos7
+  5| MAINTAINER ...
+
+If the docker image has not been built already, ``cd`` into this directory and
+then run the following command: ::
+
+  $ docker build --rm -t datm/base .
+
+Once it finishes (this can take some time), you can launch the container
+normally with the following: ::
+
+  $ docker run --rm -ti datm/base
+
+
 Development
 ===========
 
 For development on the deterministic algorithm, first clone the repo into the
 desired directory: ::
 
-  $ git clone https://github.com/ryancoffee/TimeTool_deterministic.git
+  $ git clone https://github.com/slaclab/datm.git
 
 Install the requirements using one of the methods listed above, and then add the
 project to your python path by running the ``setup.py`` file: ::


### PR DESCRIPTION
## Description

This PR adds a `Dockerfile` to the repo so there can be a unified environment for the project. Basic directions were also added to the top-level readme.

# Note

While the resulting docker container should have all the necessary components for the repo to run, it does not actually have the repo. It must be included in the container by either binding directory that has it, mounting a volume that has it, or cloning it.

Then the repo needs to be added to the python path, so follow the directions in the `Development` section of the readme.